### PR TITLE
Add BlockElement and SimpleBlockElement back

### DIFF
--- a/SpawnDev.EBML/EBMLParser.cs
+++ b/SpawnDev.EBML/EBMLParser.cs
@@ -71,7 +71,7 @@ namespace SpawnDev.EBML
             {
                 stream.Position = startPos;
                 var doc = new Document(this, stream);
-                if (doc.Data.Count() == 0)
+                if (!doc.Data.Any())
                 {
                     yield break;
                 }
@@ -92,7 +92,7 @@ namespace SpawnDev.EBML
             {
                 stream.Position = startPos;
                 var doc = new Document(this, stream);
-                if (doc.Data.Count() == 0)
+                if (!doc.Data.Any())
                 {
                     break;
                 }
@@ -133,6 +133,8 @@ namespace SpawnDev.EBML
                 case UTF8Element.TypeName: return typeof(UTF8Element);
                 case BinaryElement.TypeName: return typeof(BinaryElement);
                 case DateElement.TypeName: return typeof(DateElement);
+                case BlockElement.TypeName: return typeof(BlockElement);
+                case SimpleBlockElement.TypeName: return typeof(SimpleBlockElement);
                 default: return null;
             }
         }
@@ -292,14 +294,8 @@ namespace SpawnDev.EBML
         }
         private string[] GetEmbeddedSchemasXMLResourceNames(Assembly assembly)
         {
-            var ret = new List<string>();
             var temp = assembly.GetManifestResourceNames();
-            foreach (var name in temp)
-            {
-                if (!name.EndsWith(".xml", StringComparison.OrdinalIgnoreCase)) continue;
-                ret.Add(name);
-            }
-            return ret.ToArray();
+            return temp.Where(name => name.EndsWith(".xml", StringComparison.OrdinalIgnoreCase)).ToArray();
         }
         private string? ReadEmbeddedResourceString(Assembly assembly, string resourceName)
         {

--- a/SpawnDev.EBML/EBMLParser.cs
+++ b/SpawnDev.EBML/EBMLParser.cs
@@ -294,8 +294,14 @@ namespace SpawnDev.EBML
         }
         private string[] GetEmbeddedSchemasXMLResourceNames(Assembly assembly)
         {
+            var ret = new List<string>();
             var temp = assembly.GetManifestResourceNames();
-            return temp.Where(name => name.EndsWith(".xml", StringComparison.OrdinalIgnoreCase)).ToArray();
+            foreach (var name in temp)
+            {
+                if (!name.EndsWith(".xml", StringComparison.OrdinalIgnoreCase)) continue;
+                ret.Add(name);
+            }
+            return ret.ToArray();
         }
         private string? ReadEmbeddedResourceString(Assembly assembly, string resourceName)
         {

--- a/SpawnDev.EBML/Elements/BaseElement.cs
+++ b/SpawnDev.EBML/Elements/BaseElement.cs
@@ -1,6 +1,5 @@
-﻿using SpawnDev.EBML.Extensions;
-using SpawnDev.EBML.Segments;
-using System.Collections;
+﻿using SpawnDev.EBML.Segments;
+using SpawnDev.EBML.Extensions;
 
 namespace SpawnDev.EBML.Elements
 {

--- a/SpawnDev.EBML/Elements/BlockElement.cs
+++ b/SpawnDev.EBML/Elements/BlockElement.cs
@@ -1,0 +1,68 @@
+﻿using SpawnDev.EBML.Extensions;
+using SpawnDev.EBML.Segments;
+
+namespace SpawnDev.EBML.Elements
+{
+    public enum BlockLacing : byte
+    {
+        None = 0,
+        Xiph,
+        Fixed,
+        EBML,
+    }
+
+    public class BlockElement : BaseElement<byte[]>
+    {
+        public const string TypeName = "mkvBlock";
+
+        protected override bool EqualCheck(byte[] obj1, byte[] obj2) => obj1 == obj2 || obj1.SequenceEqual(obj2);
+
+        public BlockElement(SchemaElement schemaElement, SegmentSource source, ElementHeader? header = null) : base(schemaElement, source, header) { }
+        public BlockElement(SchemaElement schemaElement, byte[] value) : base(schemaElement, value) { }
+        public BlockElement(SchemaElement schemaElement) : base(schemaElement, Array.Empty<byte>()) { }
+
+
+        // Binary audio/video data
+        private SegmentSource? BlockData = null;
+
+        private ulong _TrackId { get; set; }
+        public ulong TrackId
+        {
+            get => _TrackId;
+            set => _TrackId = value;
+        }
+        private short _Timecode { get; set; }
+        public short Timecode
+        {
+            get => _Timecode;
+            set => _Timecode = value;
+        }
+        private byte _Flags { get; set; }
+        public byte Flags
+        {
+            get => _Flags;
+            set => _Flags = value;
+        }
+
+        public bool Invisible => (Flags & 8) != 0;
+        public BlockLacing Lacing => (BlockLacing)((Flags >> 1) & 3);
+
+        protected override void DataFromSegmentSource(ref byte[] data)
+        {
+            SegmentSource.Position = 0;
+            _TrackId = SegmentSource.ReadEBMLVINT();
+            _Timecode = BigEndian.ToInt16(SegmentSource.ReadBytes(2));
+            _Flags = SegmentSource.ReadByteOrThrow();
+            BlockData = SegmentSource.Slice(SegmentSource.Length - SegmentSource.Position);
+        }
+
+        protected override void DataToSegmentSource(ref SegmentSource source)
+        {
+            BlockData!.Position = 0;
+            source.Write(EBMLConverter.ToVINTBytes(TrackId));
+            source.Write(BigEndian.GetBytes(Timecode));
+            source.WriteByte(Flags);
+            BlockData!.CopyTo(source, 100 * 1024);
+        }
+    }
+}

--- a/SpawnDev.EBML/Elements/MasterElement.cs
+++ b/SpawnDev.EBML/Elements/MasterElement.cs
@@ -155,6 +155,22 @@ namespace SpawnDev.EBML.Elements
             AddElement(element);
             return element;
         }
+        public BlockElement? AddBlock(string name, byte[] data)
+        {
+            var schemaElement = SchemaSet.GetElement(name, DocType);
+            if (schemaElement == null || schemaElement.Type != BlockElement.TypeName) throw new Exception("Invalid element type");
+            var element = new BlockElement(schemaElement, data);
+            AddElement(element);
+            return element;
+        }
+        public BlockElement? AddSimpleBlock(string name, byte[] data)
+        {
+            var schemaElement = SchemaSet.GetElement(name, DocType);
+            if (schemaElement == null || schemaElement.Type != SimpleBlockElement.TypeName) throw new Exception("Invalid element type");
+            var element = new SimpleBlockElement(schemaElement, data);
+            AddElement(element);
+            return element;
+        }
         public TElement AddElement<TElement>(SchemaElement elementSchema) where TElement : BaseElement
         {
             var element = Create<TElement>(elementSchema);
@@ -470,6 +486,8 @@ namespace SpawnDev.EBML.Elements
                 UTF8Element.TypeName => new UTF8Element(schemaElement, source, header),
                 BinaryElement.TypeName => new BinaryElement(schemaElement, source, header),
                 DateElement.TypeName => new DateElement(schemaElement, source, header),
+                BlockElement.TypeName => new BlockElement(schemaElement, source, header),
+                SimpleBlockElement.TypeName => new SimpleBlockElement(schemaElement, source, header),
                 _ => null
             };
             return ret;
@@ -490,6 +508,8 @@ namespace SpawnDev.EBML.Elements
                 UTF8Element.TypeName => new UTF8Element(schemaElement),
                 BinaryElement.TypeName => new BinaryElement(schemaElement),
                 DateElement.TypeName => new DateElement(schemaElement),
+                BlockElement.TypeName => new BlockElement(schemaElement),
+                SimpleBlockElement.TypeName => new SimpleBlockElement(schemaElement),
                 _ => null
             };
             return (TElement?)ret;
@@ -509,6 +529,8 @@ namespace SpawnDev.EBML.Elements
                 UTF8Element.TypeName => new UTF8Element(schemaElement),
                 BinaryElement.TypeName => new BinaryElement(schemaElement),
                 DateElement.TypeName => new DateElement(schemaElement),
+                BlockElement.TypeName => new BlockElement(schemaElement),
+                SimpleBlockElement.TypeName => new SimpleBlockElement(schemaElement),
                 _ => null
             };
             return ret;

--- a/SpawnDev.EBML/Elements/SimpleBlockElement.cs
+++ b/SpawnDev.EBML/Elements/SimpleBlockElement.cs
@@ -1,0 +1,16 @@
+﻿using SpawnDev.EBML.Segments;
+
+namespace SpawnDev.EBML.Elements
+{
+    public class SimpleBlockElement : BlockElement
+    {
+        public const string TypeName = "mkvSimpleBlock";
+
+        public SimpleBlockElement(SchemaElement schemaElement, SegmentSource source, ElementHeader? header = null) : base(schemaElement, source, header) { }
+        public SimpleBlockElement(SchemaElement schemaElement, byte[] value) : base(schemaElement, value) { }
+        public SimpleBlockElement(SchemaElement schemaElement) : base(schemaElement, Array.Empty<byte>()) { }
+
+        public bool Keyframe => (Flags & 128) != 0;
+        public bool Discardable => (Flags & 1) != 0;
+    }
+}

--- a/SpawnDev.EBML/Schemas/ebml_matroska.xml
+++ b/SpawnDev.EBML/Schemas/ebml_matroska.xml
@@ -149,7 +149,7 @@ It might help to resynchronize the offset on damaged streams.</documentation>
     <extension type="libmatroska" cppname="ClusterPrevSize"/>
     <extension type="webmproject.org" webm="1"/>
   </element>
-  <element name="SimpleBlock" path="\Segment\Cluster\SimpleBlock" id="0xA3" type="binary" minver="2">
+  <element name="SimpleBlock" path="\Segment\Cluster\SimpleBlock" id="0xA3" type="mkvSimpleBlock" minver="2">
     <documentation lang="en" purpose="definition">Similar to `Block` (see (#block-structure)) but without all the extra information.
 Mostly used to reduce overhead when no extra feature is needed; see (#simpleblock-structure) on `SimpleBlock` Structure.</documentation>
     <extension type="webmproject.org" webm="1"/>
@@ -159,7 +159,7 @@ Mostly used to reduce overhead when no extra feature is needed; see (#simplebloc
     <documentation lang="en" purpose="definition">Basic container of information containing a single `Block` and information specific to that `Block`.</documentation>
     <extension type="webmproject.org" webm="1"/>
   </element>
-  <element name="Block" path="\Segment\Cluster\BlockGroup\Block" id="0xA1" type="binary" minOccurs="1" maxOccurs="1">
+  <element name="Block" path="\Segment\Cluster\BlockGroup\Block" id="0xA1" type="mkvBlock" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">`Block` containing the actual data to be rendered and a timestamp relative to the `Cluster` Timestamp;
 see (#block-structure) on `Block` Structure.</documentation>
     <extension type="webmproject.org" webm="1"/>

--- a/SpawnDev.EBML/Schemas/ebml_webm.xml
+++ b/SpawnDev.EBML/Schemas/ebml_webm.xml
@@ -149,7 +149,7 @@ It might help to resynchronize the offset on damaged streams.</documentation>
     <extension type="libmatroska" cppname="ClusterPrevSize"/>
     <extension type="webmproject.org" webm="1"/>
   </element>
-  <element name="SimpleBlock" path="\Segment\Cluster\SimpleBlock" id="0xA3" type="binary" minver="2">
+  <element name="SimpleBlock" path="\Segment\Cluster\SimpleBlock" id="0xA3" type="mkvSimpleBlock" minver="2">
     <documentation lang="en" purpose="definition">Similar to `Block` (see (#block-structure)) but without all the extra information.
 Mostly used to reduce overhead when no extra feature is needed; see (#simpleblock-structure) on `SimpleBlock` Structure.</documentation>
     <extension type="webmproject.org" webm="1"/>
@@ -159,7 +159,7 @@ Mostly used to reduce overhead when no extra feature is needed; see (#simplebloc
     <documentation lang="en" purpose="definition">Basic container of information containing a single `Block` and information specific to that `Block`.</documentation>
     <extension type="webmproject.org" webm="1"/>
   </element>
-  <element name="Block" path="\Segment\Cluster\BlockGroup\Block" id="0xA1" type="binary" minOccurs="1" maxOccurs="1">
+  <element name="Block" path="\Segment\Cluster\BlockGroup\Block" id="0xA1" type="mkvBlock" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">`Block` containing the actual data to be rendered and a timestamp relative to the `Cluster` Timestamp;
 see (#block-structure) on `Block` Structure.</documentation>
     <extension type="webmproject.org" webm="1"/>


### PR DESCRIPTION
Added back both MKV-specific blocks to :
- Facilitate header and header flags parsing
- Lower memory consumption (as binary data embedded inside these blocks won't be loaded as `byte[]` anymore, but as `SegmentSource`)